### PR TITLE
Allow fields classes to more easily control the name, label and other values used for form fields

### DIFF
--- a/tests/forms/test_form_builder.py
+++ b/tests/forms/test_form_builder.py
@@ -32,7 +32,10 @@ class FormBuilderTests(AppTestCase):
             FormBuilder(fields).formfields
         self.assertEqual(
             ex.exception.args[0],
-            "The block for singleline must contain a label of type blocks.CharBlock(required=True)",
+            "No label value can be determined for an instance of SingleLineTextField. "
+            "Add a 'label' CharBlock() in your field's get_form_block() method to allow "
+            "this to be specified by form editors. Or, override get_formfield_label() "
+            "to return a different value."
         )
 
     def test_get_form_class(self):

--- a/wagtailstreamforms/fields.py
+++ b/wagtailstreamforms/fields.py
@@ -6,6 +6,7 @@ from wagtail.core import blocks
 
 from wagtailstreamforms import hooks
 from wagtailstreamforms.utils.apps import get_app_submodules
+from wagtailstreamforms.utils.general import get_slug_from_string
 
 _fields = {}
 _searched_for_fields = False
@@ -67,6 +68,49 @@ class BaseField:
     icon = "placeholder"
     label = None
 
+    @classmethod
+    def get_formfield_name(cls, block_value):
+        """
+        Return a value to use as the 'name' for the Django form field.
+        """
+        return block_value.get("name") or get_slug_from_string(cls.get_formfield_label(block_value))
+
+    @classmethod
+    def get_formfield_label(cls, block_value):
+        """
+        Return a value to use as the 'label' for the Django form field.
+        """
+        try:
+            return block_value["label"]
+        except KeyError:
+            raise AttributeError(
+                f"No label value can be determined for an instance of {cls.__name__}. "
+                "Add a 'label' CharBlock() in your field's get_form_block() method to "
+                "allow this to be specified by form editors. Or, override "
+                "get_formfield_label() to return a different value."
+            )
+
+    @classmethod
+    def get_formfield_help_text(cls, block_value):
+        """
+        Return a value to use as the 'help_text' for the Django form field.
+        """
+        return block_value.get("help_text")
+
+    @classmethod
+    def get_formfield_initial(cls, block_value):
+        """
+        Return a 'initial' value to use for the Django form field.
+        """
+        return block_value.get("default_value")
+
+    @classmethod
+    def get_formfield_required(cls, block_value):
+        """
+        Return a boolean indicating whether the Django form field should be required.
+        """
+        return block_value.get("required", True)
+
     def get_formfield(self, block_value):
         """
         Get the form field. Its unlikely you will need to override this.
@@ -95,10 +139,10 @@ class BaseField:
         """
 
         return {
-            "label": block_value.get("label"),
-            "help_text": block_value.get("help_text"),
-            "required": block_value.get("required"),
-            "initial": block_value.get("default_value"),
+            "label": self.get_formfield_label(block_value),
+            "help_text": self.get_formfield_help_text(block_value),
+            "required": self.get_formfield_required(block_value),
+            "initial": self.get_formfield_initial(block_value),
         }
 
     def get_form_block(self):

--- a/wagtailstreamforms/forms.py
+++ b/wagtailstreamforms/forms.py
@@ -38,18 +38,9 @@ class FormBuilder:
                     "Could not find a registered field of type %s" % field_type
                 )
 
-            # check there is a label
-            if "label" not in field_value:
-                raise AttributeError(
-                    "The block for %s must contain a label of type blocks.CharBlock(required=True)"
-                    % field_type
-                )
-
-            # slugify the label for the field name
-            field_name = get_slug_from_string(field_value.get("label"))
-
             # get the field
             registered_cls = registered_fields[field_type]()
+            field_name = registered_cls.get_formfield_name(field_value)
             field_cls = registered_cls.get_formfield(field_value)
             formfields[field_name] = field_cls
 


### PR DESCRIPTION
Resolves #142. Supersedes #149.

For example, this allows custom fields to:

- Specify a 'name' block to use as the form field name - or have that derived from some other value ('label' by default), or even a hardcoded value on the class
- Specify 'label', 'help_text', 'required' and 'initial' values for the field without them being present in the block value (e.g. these could be hardcoded on field classes to avoid clunking up the UI with additional fields)