### PR TITLE
Fix tests for wagtail 2.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - run: apt-get update
-      - run: apt-get install libjpeg-dev
+      - run: apt-get install -y libjpeg-dev
       - run: pip install --upgrade codecov
       - run: tox -v
       - run: codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - image: themattrix/tox
     steps:
       - checkout
+      - run: apt-get install libjpeg-dev
       - run: pip install --upgrade codecov
       - run: tox -v
       - run: codecov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - image: themattrix/tox
     steps:
       - checkout
+      - run: apt-get update
       - run: apt-get install libjpeg-dev
       - run: pip install --upgrade codecov
       - run: tox -v

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -132,7 +132,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          apt-get install libjpeg-dev
+          apt-get update
+          apt-get install -y libjpeg-dev
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions
       - name: Test with tox

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -132,6 +132,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          apt-get install libjpeg-dev
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions
       - name: Test with tox

--- a/example/settings.py
+++ b/example/settings.py
@@ -58,7 +58,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
+import os
+import re
 from django.urls import reverse_lazy
 
 SECRET_KEY = "secret"
@@ -37,9 +39,27 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "wagtail.core.middleware.SiteMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
+
+WAGTAIL_VERSION = re.search("wt[0-9]*", os.environ["TOX_ENV_NAME"])[0]
+
+PRE_WAGTAIL_211_VERSIONS = [
+    "wt23",
+    "wt24",
+    "wt25",
+    "wt26",
+    "wt27",
+    "wt28",
+    "wt29",
+    "wt210"
+]
+
+PRE_WAGTAIL_211 = False
+
+if WAGTAIL_VERSION in PRE_WAGTAIL_211_VERSIONS:
+     MIDDLEWARE.append("wagtail.core.middleware.SiteMiddleware")
+     PRE_WAGTAIL_211 = True
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": "testdb"}}
 

--- a/tests/views/test_copy.py
+++ b/tests/views/test_copy.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.urls import reverse
 from wagtailstreamforms.models import Form
@@ -78,7 +79,11 @@ class CopyViewPermissionTestCase(AppTestCase):
         self.client.login(username="user", password="password")
 
         response = self.client.get(self.copy_url)
-        self.assertEqual(response.status_code, 403)
+        if settings.PRE_WAGTAIL_211:
+            self.assertEqual(response.status_code, 403)
+        else:
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(response.url.startswith("/cms/"))
 
     def test_user_with_add_perm_has_access(self):
         access_admin = Permission.objects.get(codename="access_admin")

--- a/tests/views/test_delete.py
+++ b/tests/views/test_delete.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.urls import reverse
 from wagtailstreamforms.models import Form, FormSubmission
@@ -100,7 +101,11 @@ class DeleteViewPermissionTestCase(AppTestCase):
         self.client.login(username="user", password="password")
 
         response = self.client.get(self.delete_url)
-        self.assertEqual(response.status_code, 403)
+        if settings.PRE_WAGTAIL_211:
+            self.assertEqual(response.status_code, 403)
+        else:
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(response.url.startswith("/cms/"))
 
     def test_user_with_delete_perm_has_access(self):
         access_admin = Permission.objects.get(codename="access_admin")

--- a/tests/views/test_submission_list.py
+++ b/tests/views/test_submission_list.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-
+from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.urls import reverse
 
@@ -96,7 +96,11 @@ class ListViewPermissionTestCase(AppTestCase):
         self.client.login(username="user", password="password")
 
         response = self.client.get(self.list_url)
-        self.assertEqual(response.status_code, 403)
+        if settings.PRE_WAGTAIL_211:
+            self.assertEqual(response.status_code, 403)
+        else:
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(response.url.startswith("/cms/"))
 
     def test_user_with_add_perm_has_access(self):
         access_admin = Permission.objects.get(codename="access_admin")


### PR DESCRIPTION
Fixing the tests for wagtail 2.11 as mentioned in [issue 158](https://github.com/labd/wagtailstreamforms/issues/158)

There were two [changes](https://docs.wagtail.io/en/v2.11.2/releases/2.11.html) in wagtail 2.11 that broke the tests:

> Consistently redirect to admin home on permission denied (Matt Westcott, Anton Zhyltsou)

When using wagtail 2.11, permission denied errors are redirected to the home page rather than returning a 403.

> SiteMiddleware moved to wagtail.contrib.legacy

We need to remove `wagtail.core.middleware.SiteMiddleware` from the settings.py file unless the tests are running in an older version of wagtail, in which case we still need it as version 2.8 of wagtail uses it [here](https://github.com/wagtail/wagtail/blob/v2.8/wagtail/core/views.py#L13)

I've not used `tox` before, so I'm unsure if there's a cleverer way to go about these dynamic tests. Let me know if I can improve it in any way