### PR TITLE
Fix handling of '&' URL separators in tests

### DIFF
--- a/tests/templatetags/test_url_replace.py
+++ b/tests/templatetags/test_url_replace.py
@@ -1,3 +1,4 @@
+from html import unescape
 import urllib.parse as urlparse
 
 from ..test_case import AppTestCase
@@ -11,7 +12,7 @@ class TemplateTagTests(AppTestCase):
             {"request": fake_request},
         )
         # parse the url as they can be reordered unpredictably
-        parsed = urlparse.parse_qs(urlparse.urlparse(rendered).query)
+        parsed = urlparse.parse_qs(urlparse.urlparse(unescape(rendered)).query)
         self.assertDictEqual(parsed, {"page": ["1"]})
 
     def test_kwarg_appended(self):
@@ -21,7 +22,7 @@ class TemplateTagTests(AppTestCase):
             {"request": fake_request},
         )
         # parse the url as they can be reordered unpredictably
-        parsed = urlparse.parse_qs(urlparse.urlparse(rendered).query)
+        parsed = urlparse.parse_qs(urlparse.urlparse(unescape(rendered)).query)
         self.assertDictEqual(parsed, {"foo": ["bar"], "page": ["1"]})
 
     def test_kwarg_replaced(self):
@@ -31,5 +32,5 @@ class TemplateTagTests(AppTestCase):
             {"request": fake_request},
         )
         # parse the url as they can be reordered unpredictably
-        parsed = urlparse.parse_qs(urlparse.urlparse(rendered).query)
+        parsed = urlparse.parse_qs(urlparse.urlparse(unescape(rendered)).query)
         self.assertDictEqual(parsed, {"foo": ["bar"], "page": ["5"]})


### PR DESCRIPTION
Current Python versions as of February 2021 no longer treat the ; character as a URL parameter separator: https://python-security.readthedocs.io/vuln/urllib-query-string-semicolon-separator.html

This breaks the tests for the url_replace tag, as they attempt to parse a URL generated by a Django template. HTML autoescaping is enabled, so & characters in the URL will be escaped as &amp;. This discrepancy between escaped and unescaped HTML was previously masked because the closing ; was also treated as a separator.