### PR TITLE
Wagtail 2.12 compatibility

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,6 +31,7 @@ jobs:
           - py36-dj22-wt29
           - py36-dj22-wt210
           - py36-dj22-wt211
+          - py36-dj22-wt212
           - py37-dj22-wt25
           - py37-dj22-wt26
           - py37-dj22-wt27
@@ -38,6 +39,7 @@ jobs:
           - py37-dj22-wt29
           - py37-dj22-wt210
           - py37-dj22-wt211
+          - py37-dj22-wt212
           - py38-dj22-wt25
           - py38-dj22-wt26
           - py38-dj22-wt27
@@ -45,14 +47,17 @@ jobs:
           - py38-dj22-wt29
           - py38-dj22-wt210
           - py38-dj22-wt211
+          - py38-dj22-wt212
           - py37-dj30-wt28
           - py37-dj30-wt29
           - py37-dj30-wt210
           - py37-dj30-wt211
+          - py37-dj30-wt212
           - py38-dj30-wt28
           - py38-dj30-wt29
           - py38-dj30-wt210
           - py38-dj30-wt211
+          - py38-dj30-wt212
         include:
           - python-version: 3.6
             tox_env: py36-dj22-wt25
@@ -68,6 +73,8 @@ jobs:
             tox_env: py36-dj22-wt210
           - python-version: 3.6
             tox_env: py36-dj22-wt211
+          - python-version: 3.6
+            tox_env: py36-dj22-wt212
           - python-version: 3.7
             tox_env: py37-dj22-wt25
           - python-version: 3.7
@@ -82,6 +89,8 @@ jobs:
             tox_env: py37-dj22-wt210
           - python-version: 3.7
             tox_env: py37-dj22-wt211
+          - python-version: 3.7
+            tox_env: py37-dj22-wt212
           - python-version: 3.8
             tox_env: py38-dj22-wt25
           - python-version: 3.8
@@ -96,6 +105,8 @@ jobs:
             tox_env: py38-dj22-wt210
           - python-version: 3.8
             tox_env: py38-dj22-wt211
+          - python-version: 3.8
+            tox_env: py38-dj22-wt212
           - python-version: 3.7
             tox_env: py37-dj30-wt28
           - python-version: 3.7
@@ -104,6 +115,8 @@ jobs:
             tox_env: py37-dj30-wt210
           - python-version: 3.7
             tox_env: py37-dj30-wt211
+          - python-version: 3.7
+            tox_env: py37-dj30-wt212
           - python-version: 3.8
             tox_env: py38-dj30-wt28
           - python-version: 3.8
@@ -112,6 +125,8 @@ jobs:
             tox_env: py38-dj30-wt210
           - python-version: 3.8
             tox_env: py38-dj30-wt211
+          - python-version: 3.8
+            tox_env: py38-dj30-wt212
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,10 @@ tests_require = [
 ]
 
 
-install_requires = ["wagtail>=2,<2.12"]
+install_requires = [
+    "wagtail>=2,<2.13",
+    "Unidecode>=0.04.14,<2.0",
+]
 
 documentation_extras = [
     "sphinxcontrib-spelling>=2.3.0",

--- a/tests/templatetags/test_url_replace.py
+++ b/tests/templatetags/test_url_replace.py
@@ -1,3 +1,4 @@
+from html import unescape
 import urllib.parse as urlparse
 
 from ..test_case import AppTestCase
@@ -11,7 +12,7 @@ class TemplateTagTests(AppTestCase):
             {"request": fake_request},
         )
         # parse the url as they can be reordered unpredictably
-        parsed = urlparse.parse_qs(urlparse.urlparse(rendered).query)
+        parsed = urlparse.parse_qs(urlparse.urlparse(unescape(rendered)).query)
         self.assertDictEqual(parsed, {"page": ["1"]})
 
     def test_kwarg_appended(self):
@@ -21,7 +22,7 @@ class TemplateTagTests(AppTestCase):
             {"request": fake_request},
         )
         # parse the url as they can be reordered unpredictably
-        parsed = urlparse.parse_qs(urlparse.urlparse(rendered).query)
+        parsed = urlparse.parse_qs(urlparse.urlparse(unescape(rendered)).query)
         self.assertDictEqual(parsed, {"foo": ["bar"], "page": ["1"]})
 
     def test_kwarg_replaced(self):
@@ -31,5 +32,5 @@ class TemplateTagTests(AppTestCase):
             {"request": fake_request},
         )
         # parse the url as they can be reordered unpredictably
-        parsed = urlparse.parse_qs(urlparse.urlparse(rendered).query)
+        parsed = urlparse.parse_qs(urlparse.urlparse(unescape(rendered)).query)
         self.assertDictEqual(parsed, {"foo": ["bar"], "page": ["5"]})

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     flake8
-    py{36,37,38}-dj{22}-wt{25,26,27,28,29,210,211}
-    py{37,38}-dj{30}-wt{28,29,210,211}
+    py{36,37,38}-dj{22}-wt{25,26,27,28,29,210,211,212}
+    py{37,38}-dj{30,31}-wt{28,29,210,211,212}
 
 [gh-actions]
 python =
@@ -17,6 +17,7 @@ deps =
 
     dj22: Django>=2.2.8,<2.3
     dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
     wt23: wagtail>=2.3,<2.4
     wt24: wagtail>=2.4,<2.5
     wt25: wagtail>=2.5,<2.6
@@ -26,6 +27,7 @@ deps =
     wt29: wagtail>=2.9,<2.10
     wt210: wagtail>=2.10,<2.11
     wt211: wagtail>=2.11,<2.12
+    wt212: wagtail>=2.12,<2.13
 
 
 commands =

--- a/wagtailstreamforms/models/form.py
+++ b/wagtailstreamforms/models/form.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.edit_handlers import (
     FieldPanel,
     MultiFieldPanel,
@@ -162,9 +163,12 @@ class AbstractForm(models.Model):
         return FormBuilder(self.get_form_fields()).get_form_class()
 
     def get_form_fields(self):
-        """ Returns the form fields stream_data. """
+        """ Returns the form field's stream data. """
 
-        form_fields = self.fields.stream_data
+        if WAGTAIL_VERSION >= (2, 12):
+            form_fields = self.fields.raw_data
+        else:
+            form_fields = self.fields.stream_data
         for fn in hooks.get_hooks("construct_submission_form_fields"):
             form_fields = fn(form_fields)
         return form_fields


### PR DESCRIPTION
Addresses #167 

* Add unidecode as an explicit dependency (fixes #168)
* Use StreamValue.raw_data in preference to StreamValue.stream_data (deprecated in 2.12)
* Add Wagtail 2.12 to dependency range and test matrix
* Also incorporates #168