### PR TITLE
Fix missing ModelAdmin menu_icon for Wagtail 2.11+

### DIFF
--- a/wagtailstreamforms/wagtail_hooks.py
+++ b/wagtailstreamforms/wagtail_hooks.py
@@ -7,6 +7,7 @@ from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
+from wagtail import VERSION
 from wagtail.admin import messages as wagtail_messages
 from wagtail.contrib.modeladmin.helpers import AdminURLHelper, ButtonHelper
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
@@ -144,7 +145,11 @@ class FormModelAdmin(ModelAdmin):
     list_filter = None
     menu_label = _(get_setting("ADMIN_MENU_LABEL"))
     menu_order = get_setting("ADMIN_MENU_ORDER")
-    menu_icon = "icon icon-form"
+    menu_icon = (
+        "icon icon-form"
+        if VERSION[0] < 2 or (VERSION[0] == 2 and VERSION[1] < 11)
+        else "form"
+    )
     search_fields = ("title", "slug")
     button_helper_class = FormButtonHelper
     inspect_view_class = InspectFormView


### PR DESCRIPTION
I noticed that the "form" icon in the main menu is missing from Wagtail 2.11 onwards.
I'm not sure which commit between 2.10.2 and 2.11 is at fault but here's my PR to fix it.

Looks like simply changing the value to `"form"` also works before 2.11 but I wanted to make sure that I don't break anything so I relied on Wagtail's `VERSION`.

Not sure if this trivial change needs some testing (TBH i also don't know how to test Wagtail icons).

Please let me know if somethings is wrong or missing.