### PR TITLE
Add export as XLSX format option

### DIFF
--- a/tests/views/test_submission_list.py
+++ b/tests/views/test_submission_list.py
@@ -39,6 +39,9 @@ class SubmissionListViewTestCase(AppTestCase):
         self.csv_url = "{}?date_from=2017-01-01&date_to=2017-01-02&action=CSV".format(
             self.list_url
         )
+        self.xlsx_url = "{}?date_from=2017-01-01&date_to=2017-01-02&action=XLSX".format(
+            self.list_url
+        )
 
         self.client.login(username="user", password="password")
 
@@ -69,6 +72,12 @@ class SubmissionListViewTestCase(AppTestCase):
         response = self.client.get(self.csv_url)
         self.assertEqual(
             response.get("Content-Disposition"), "attachment;filename=export.csv"
+        )
+
+    def test_get_xlsx(self):
+        response = self.client.get(self.xlsx_url)
+        self.assertEqual(
+            response.get("Content-Disposition"), "attachment;filename=export.xlsx"
         )
 
 

--- a/wagtailstreamforms/templates/streamforms/index_submissions.html
+++ b/wagtailstreamforms/templates/streamforms/index_submissions.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans with form_title=object.title|capfirst %}Submissions of {{ form_title }}{% endblocktrans %}{% endblock %}
 {% block extra_js %}
     {{ block.super }}
@@ -86,7 +86,13 @@
                     </div>
                 </div>
                 <div class="right">
-                    <button name="action" value="CSV" class="button bicolor icon icon-download">{% trans 'Download CSV' %}</button>
+                    <div class="dropdown dropdown-button match-width">
+                        <button name="action" value="XLSX" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</button>
+                        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
+                        <ul>
+                            <li><button name="action" value="CSV" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</button><li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
Features:
- Add XLSX format as an export option

Known limitation
- [custom_value_preprocess](https://docs.wagtail.io/en/stable/advanced_topics/adding_reports.html#custom_value_preprocess) is not implemented. It's not implemented for CSV format anyway. Could be a further improvement.