### PR TITLE
Add an option to show the form reference field in the list view and export

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -27,3 +27,6 @@ Any settings with their defaults are listed below for quick reference.
     WAGTAILSTREAMFORMS_FORM_TEMPLATES = (
         ('streamforms/form_block.html', 'Default Form Template'),
     )
+
+    # show the form reference field in the list view and export
+    WAGTAILSTREAMFORMS_SHOW_FORM_REFERENCE = True

--- a/wagtailstreamforms/models/form.py
+++ b/wagtailstreamforms/models/form.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from wagtail import VERSION as WAGTAIL_VERSION
@@ -149,7 +150,8 @@ class AbstractForm(models.Model):
             (get_slug_from_string(field["value"]["label"]), field["value"]["label"])
             for field in self.get_form_fields()
         ]
-
+        if getattr(settings, "WAGTAILSTREAMFORMS_SHOW_FORM_REFERENCE", False):
+            data_fields += [("form_reference", _("Form reference"))]
         return data_fields
 
     def get_form(self, *args, **kwargs):


### PR DESCRIPTION
It's useful to have an option to show the form reference field in the list view and export. To help track the "source" when embedding a stream form into different pages.