### PR TITLE
Allowing installing w/ wagtail 3.0.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - 8000:8000
   db:
-    image: postgres:9.6
+    image: postgres:11
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password

--- a/example/settings.py
+++ b/example/settings.py
@@ -38,7 +38,6 @@ INSTALLED_APPS = [
     'wagtail.contrib.redirects',
     'wagtail.sites',
     'wagtail.contrib.modeladmin',
-    'wagtail.contrib.postgres_search',
     'wagtail.contrib.settings',
     'wagtail.contrib.search_promotions',
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_require = [
 
 
 install_requires = [
-    "wagtail>=2,<2.17",
+    "wagtail>=2,<=3.0.3",
     "Unidecode>=0.04.14,<2.0",
 ]
 

--- a/tests/fields/test_hook_select_field.py
+++ b/tests/fields/test_hook_select_field.py
@@ -1,6 +1,5 @@
 from django.core import serializers
 from django.core.exceptions import ValidationError
-from django.db import models
 from django.forms import CheckboxSelectMultiple
 
 from wagtailstreamforms.fields import HookMultiSelectFormField, HookSelectField

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     flake8
-    py{37,38,39,310}-dj{32,40}-wt{215,216}
+    py{37,38,39,310}-dj{32,40}-wt{215,216,30,40}
 
 [gh-actions]
 python =
@@ -18,6 +18,8 @@ deps =
     dj40: Django>=4.0,<4.1
     wt215: wagtail>=2.15,<2.16
     wt216: wagtail>=2.16,<2.17
+    wt30: wagtail==3.0.*
+    wt40: wagtail==4.0.*
 
 commands =
     coverage run manage.py test


### PR DESCRIPTION
I tested the example project w/ version 3.0.3 and it seemed to work. 

tox ran and all tests passed.

Was able to create a basic form, a page, publish the page and submit the form. 


4.0.* did not work due to some issue with the FormChooser when trying to add a page.  Will create an issue with the stack trace.

